### PR TITLE
[GCB-Webpack] Handle errors that occur when calling toJson on the webpack stats object.

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-webpack/handle-stats-error_2022-02-05-00-05.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/handle-stats-error_2022-02-05-00-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "comment": "Handle errors that occur when calling toJson on the webpack stats object.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-webpack",
+  "email": "iclanton@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/SharePoint/sp-dev-docs/issues/7691

## Details

This just wraps the `stats.toJson` call in a try/catch.

## How it was tested

Ran locally in a SPFx project.