### PR TITLE
gcb-typescript: remove rushstack compiler 3.2 dep

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-typescript/gcb-ts-remove-rushstach-3.2_2022-03-30-00-13.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/gcb-ts-remove-rushstach-3.2_2022-03-30-00-13.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/gulp-core-build-typescript",
-      "comment": "removing inline dependency on rushstack compiler v3.2",
+      "comment": "Update a dependency on RSC-3.2 to point to RSC-4.5.",
       "type": "patch"
     }
   ],

--- a/common/changes/@microsoft/gulp-core-build-typescript/gcb-ts-remove-rushstach-3.2_2022-03-30-00-13.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/gcb-ts-remove-rushstach-3.2_2022-03-30-00-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "removing inline dependency on rushstack compiler v3.2",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript",
+  "email": "="
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/gcb-ts-remove-rushstach-3.2_2022-03-30-00-13.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/gcb-ts-remove-rushstach-3.2_2022-03-30-00-13.json
@@ -7,5 +7,5 @@
     }
   ],
   "packageName": "@microsoft/gulp-core-build-typescript",
-  "email": "="
+  "email": "aterentiev@microsoft.com"
 }

--- a/core-build/gulp-core-build-typescript/src/RSCTask.ts
+++ b/core-build/gulp-core-build-typescript/src/RSCTask.ts
@@ -60,7 +60,7 @@ export abstract class RSCTask<TTaskConfig extends IRSCTaskConfig> extends GulpTa
             'Unable to resolve rush-stack-compiler from tsconfig.json. Using built-in compiler'
           );
           const builtInCompilerPath: string | undefined = RSCTask._packageJsonLookup.tryGetPackageFolderFor(
-            require.resolve('@microsoft/rush-stack-compiler-3.2')
+            require.resolve('@microsoft/rush-stack-compiler-4.5')
           );
           if (!builtInCompilerPath) {
             throw new Error(


### PR DESCRIPTION
## Summary
The PR removes dependency to rushstack compimer 3.2 from gcb-typescript

## Details
This is needed to remove errors like these:
```
Error - [lint] Error: Cannot find module '@microsoft/rush-stack-compiler-3.2'
Require stack:
- D:\at\tests\ts-4-gen\3\node_modules\@microsoft\gulp-core-build-typescript\lib\RSCTask.js
- D:\at\tests\ts-4-gen\3\node_modules\@microsoft\gulp-core-build-typescript\lib\TscCmdTask.js
- D:\at\tests\ts-4-gen\3\node_modules\@microsoft\gulp-core-build-typescript\lib\index.js
```