### PR TITLE
Allow quietDeps in sass config

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-sass/user-aterentiev-sass-quiet-deps_2022-10-19-13-24.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/user-aterentiev-sass-quiet-deps_2022-10-19-13-24.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/gulp-core-build-sass",
-      "comment": "allow quietDeps in sass config",
+      "comment": "Add a `quietDeps` sass config option that silences compiler warnings from dependencies.",
       "type": "minor"
     }
   ],

--- a/common/changes/@microsoft/gulp-core-build-sass/user-aterentiev-sass-quiet-deps_2022-10-19-13-24.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/user-aterentiev-sass-quiet-deps_2022-10-19-13-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "allow quietDeps in sass config",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass"
+}

--- a/core-build/gulp-core-build-sass/src/SassTask.ts
+++ b/core-build/gulp-core-build-sass/src/SassTask.ts
@@ -83,6 +83,11 @@ export interface ISassTaskConfig {
    * Allows the override of generateScopedName function in CSSModule.
    */
   generateScopedName?: (name: string, fileName: string, css: string) => string;
+
+  /**
+   * Silence compiler warnings from dependencies
+   */
+  quietDeps?: boolean;
 }
 
 export class SassTask extends GulpTask<ISassTaskConfig> {
@@ -101,7 +106,8 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
       warnOnCssInvalidPropertyName: true,
       dropCssFiles: false,
       warnOnNonCSSModules: false,
-      autoprefixerOptions: { overrideBrowserslist: ['> 1%', 'last 2 versions', 'ie >= 10'] }
+      autoprefixerOptions: { overrideBrowserslist: ['> 1%', 'last 2 versions', 'ie >= 10'] },
+      quietDeps: false
     });
   }
 
@@ -159,7 +165,8 @@ export class SassTask extends GulpTask<ISassTaskConfig> {
       sourceMap: this.taskConfig.dropCssFiles,
       sourceMapContents: true,
       omitSourceMapUrl: true,
-      outFile: cssOutputPath
+      outFile: cssOutputPath,
+      quietDeps: !!this.taskConfig.quietDeps
     })
       .catch((error: sass.SassException) => {
         this.fileError(filePath, error.line, error.column, error.name, error.message);

--- a/core-build/gulp-core-build-sass/src/sass.schema.json
+++ b/core-build/gulp-core-build-sass/src/sass.schema.json
@@ -51,6 +51,12 @@
       "title": "Create CSS Files",
       "description": "If true, we will generate a CSS in the lib folder. If false, the CSS is directly embedded into the TypeScript file",
       "type": "boolean"
+    },
+
+    "quietDeps": {
+      "title": "Silence compiler warnings from dependencies",
+      "description": "If true, silences compiler warnings from stylesheets loaded through importers and load paths.",
+      "type": "boolean"
     }
   }
 }


### PR DESCRIPTION
## Summary

Allows to set `quietDeps` property is sass config

## Details

The change allows a developer to set `quietDeps` property to `true` to avoid bombarding the terminal with warnings about deprecated sass rules from dependencies.

## How it was tested

Tested in SPFx solution.