### PR TITLE
Update gulp-connect dependency.

### DIFF
--- a/common/changes/@microsoft/gulp-core-build-serve/update-dep_2023-03-01-20-01.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/update-dep_2023-03-01-20-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "Update gulp-connect to ~5.7.0 because of a vulnerability in the \"qs\" dependency.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -537,7 +537,7 @@ importers:
       eslint: ~7.12.1
       express: ~4.16.2
       gulp: ~4.0.2
-      gulp-connect: ~5.5.0
+      gulp-connect: ~5.7.0
       gulp-open: ~3.0.1
       sudo: ~1.0.3
     dependencies:
@@ -548,7 +548,7 @@ importers:
       colors: 1.2.5
       express: 4.16.4
       gulp: 4.0.2
-      gulp-connect: 5.5.0
+      gulp-connect: 5.7.0
       gulp-open: 3.0.1
       sudo: 1.0.3
     devDependencies:
@@ -3538,6 +3538,11 @@ packages:
     dependencies:
       ansi-wrap: 0.1.0
 
+  /ansi-colors/2.0.5:
+    resolution: {integrity: sha512-yAdfUZ+c2wetVNIFsNRn44THW+Lty6S5TwMpUfLA/UaGhiXbBv/F8E60/1hMLd0cnF/CDoWH8vzVaI5bAcHCjw==}
+    engines: {node: '>=6'}
+    dev: false
+
   /ansi-colors/4.1.1:
     resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==}
     engines: {node: '>=6'}
@@ -3549,7 +3554,7 @@ packages:
       type-fest: 0.21.3
 
   /ansi-gray/0.1.1:
-    resolution: {integrity: sha1-KWLPVOyXksSFEKPetSRDaGHvclE=}
+    resolution: {integrity: sha512-HrgGIZUl8h2EHuZaU9hTR/cU5nhKxpVE1V6kdGsQ8e4zirElJ5fvtfc8N7Q1oq1aatO275i8pUFUCpNWCAnVWw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-wrap: 0.1.0
@@ -3592,7 +3597,7 @@ packages:
     dev: true
 
   /ansi-wrap/0.1.0:
-    resolution: {integrity: sha1-qCJQ3bABXponyoLoLqYDu/pF768=}
+    resolution: {integrity: sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==}
     engines: {node: '>=0.10.0'}
 
   /anymatch/2.0.0:
@@ -4016,7 +4021,7 @@ packages:
     dev: false
 
   /batch/0.6.1:
-    resolution: {integrity: sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=}
+    resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
     dev: false
 
   /bcrypt-pbkdf/1.0.2:
@@ -4062,22 +4067,6 @@ packages:
     resolution: {integrity: sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==}
     dev: false
 
-  /body-parser/1.14.2:
-    resolution: {integrity: sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      bytes: 2.2.0
-      content-type: 1.0.4
-      debug: 2.2.0
-      depd: 1.1.2
-      http-errors: 1.3.1
-      iconv-lite: 0.4.13
-      on-finished: 2.3.0
-      qs: 5.2.0
-      raw-body: 2.1.7
-      type-is: 1.6.18
-    dev: false
-
   /body-parser/1.18.3:
     resolution: {integrity: sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=}
     engines: {node: '>= 0.8'}
@@ -4092,6 +4081,15 @@ packages:
       qs: 6.5.2
       raw-body: 2.3.3
       type-is: 1.6.18
+    dev: false
+
+  /body/5.1.0:
+    resolution: {integrity: sha512-chUsBxGRtuElD6fmw1gHLpvnKdVLK302peeFa9ZqAEk8TyzZ3fygLyUEDDPTJvL9+Bor0dIwn6ePOsRM2y0zQQ==}
+    dependencies:
+      continuable-cache: 0.3.1
+      error: 7.2.1
+      raw-body: 1.1.7
+      safe-json-parse: 1.0.1
     dev: false
 
   /brace-expansion/1.1.11:
@@ -4234,12 +4232,8 @@ packages:
     resolution: {integrity: sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=}
     dev: false
 
-  /bytes/2.2.0:
-    resolution: {integrity: sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg=}
-    dev: false
-
-  /bytes/2.4.0:
-    resolution: {integrity: sha1-fZcZb51br39pNeJZhVSe3SpsIzk=}
+  /bytes/1.0.0:
+    resolution: {integrity: sha512-/x68VkHLeTl3/Ll8IvxdwzhrT+IyKc52e/oyHhA2RwqPqswSnjVbSddfPRwAsJtbilMAPSRWwAlpxdYsSWOTKQ==}
     dev: false
 
   /bytes/3.0.0:
@@ -4580,8 +4574,8 @@ packages:
       readable-stream: 2.3.7
       typedarray: 0.0.6
 
-  /connect-livereload/0.5.4:
-    resolution: {integrity: sha1-gBV9E3HJ83zBQDmrGJWXDRGdw7w=}
+  /connect-livereload/0.6.1:
+    resolution: {integrity: sha512-3R0kMOdL7CjJpU66fzAkCe6HNtd3AavCS4m+uW4KtJjrdGPT0SQEZieAYd+cm+lJoBznNQ4lqipYWkhBMgk00g==}
     dev: false
 
   /connect/3.7.0:
@@ -4610,6 +4604,10 @@ packages:
   /content-type/1.0.4:
     resolution: {integrity: sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /continuable-cache/0.3.1:
+    resolution: {integrity: sha512-TF30kpKhTH8AGCG3dut0rdd/19B7Z+qCnrMoBLpyQu/2drZdNrrpcjPEoJeSVsQM+8KmWG5O56oPDjSSUsuTyA==}
     dev: false
 
   /convert-source-map/1.7.0:
@@ -4807,12 +4805,6 @@ packages:
   /dateformat/2.2.0:
     resolution: {integrity: sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=}
 
-  /debug/2.2.0:
-    resolution: {integrity: sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=}
-    dependencies:
-      ms: 0.7.1
-    dev: false
-
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     dependencies:
@@ -4937,7 +4929,7 @@ packages:
     engines: {node: '>=0.4.0'}
 
   /depd/1.1.2:
-    resolution: {integrity: sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=}
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -4949,7 +4941,7 @@ packages:
     dev: false
 
   /destroy/1.0.4:
-    resolution: {integrity: sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=}
+    resolution: {integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==}
     dev: false
 
   /detect-file/1.0.0:
@@ -5020,10 +5012,6 @@ packages:
       webidl-conversions: 5.0.0
     dev: true
 
-  /duplexer/0.1.2:
-    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
-    dev: false
-
   /duplexer2/0.0.2:
     resolution: {integrity: sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=}
     dependencies:
@@ -5050,7 +5038,7 @@ packages:
       safer-buffer: 2.1.2
 
   /ee-first/1.1.1:
-    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
     dev: false
 
   /electron-to-chromium/1.3.739:
@@ -5085,7 +5073,7 @@ packages:
     dev: false
 
   /encodeurl/1.0.2:
-    resolution: {integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=}
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
     dev: false
 
@@ -5125,6 +5113,12 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
+
+  /error/7.2.1:
+    resolution: {integrity: sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==}
+    dependencies:
+      string-template: 0.2.1
+    dev: false
 
   /es-abstract/1.18.2:
     resolution: {integrity: sha512-byRiNIQXE6HWNySaU6JohoNXzYgbBjztwFnBLUTiJmWXjaU9bSq3urQLUlNLQ292tc+gc07zYZXNZjaOoAX3sw==}
@@ -5213,7 +5207,7 @@ packages:
     engines: {node: '>=6'}
 
   /escape-html/1.0.3:
-    resolution: {integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=}
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
     dev: false
 
   /escape-string-regexp/1.0.5:
@@ -5598,26 +5592,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  /etag/1.7.0:
-    resolution: {integrity: sha1-A9MLX2fdbmMtKUXTDWZScxo01dg=}
-    engines: {node: '>= 0.6'}
-    dev: false
-
   /etag/1.8.1:
-    resolution: {integrity: sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=}
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
-    dev: false
-
-  /event-stream/3.3.5:
-    resolution: {integrity: sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==}
-    dependencies:
-      duplexer: 0.1.2
-      from: 0.1.7
-      map-stream: 0.0.7
-      pause-stream: 0.0.11
-      split: 1.0.1
-      stream-combiner: 0.2.2
-      through: 2.3.8
     dev: false
 
   /events/3.3.0:
@@ -5862,7 +5839,7 @@ packages:
       reusify: 1.0.4
 
   /faye-websocket/0.10.0:
-    resolution: {integrity: sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=}
+    resolution: {integrity: sha512-Xhj93RXbMSq8urNCUq4p9l0P6hnySJ/7YNRhYNug0bLOuii7pKO7xQFb5mx9xZXWCar88pLPb805PvUkwrLZpQ==}
     engines: {node: '>=0.4.0'}
     dependencies:
       websocket-driver: 0.7.4
@@ -6076,18 +6053,9 @@ packages:
     dependencies:
       map-cache: 0.2.2
 
-  /fresh/0.3.0:
-    resolution: {integrity: sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=}
-    engines: {node: '>= 0.6'}
-    dev: false
-
   /fresh/0.5.2:
-    resolution: {integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=}
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
-    dev: false
-
-  /from/0.1.7:
-    resolution: {integrity: sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=}
     dev: false
 
   /from2/2.3.0:
@@ -6414,19 +6382,19 @@ packages:
       v8flags: 3.2.0
       yargs: 7.1.2
 
-  /gulp-connect/5.5.0:
-    resolution: {integrity: sha512-oRBLjw/4EVaZb8g8OcxOVdGD8ZXYrRiWKcNxlrGjxb/6Cp0GDdqw7ieX7D8xJrQS7sbXT+G94u63pMJF3MMjQA==}
+  /gulp-connect/5.7.0:
+    resolution: {integrity: sha512-8tRcC6wgXMLakpPw9M7GRJIhxkYdgZsXwn7n56BA2bQYGLR9NOPhMzx7js+qYDy6vhNkbApGKURjAw1FjY4pNA==}
     engines: {node: '>=0.10.0'}
     dependencies:
-      ansi-colors: 1.1.0
+      ansi-colors: 2.0.5
       connect: 3.7.0
-      connect-livereload: 0.5.4
-      event-stream: 3.3.5
+      connect-livereload: 0.6.1
       fancy-log: 1.3.3
-      send: 0.13.2
+      map-stream: 0.0.7
+      send: 0.16.2
       serve-index: 1.9.1
       serve-static: 1.14.1
-      tiny-lr: 0.2.1
+      tiny-lr: 1.1.1
     dev: false
 
   /gulp-flatten/0.2.0:
@@ -6675,22 +6643,14 @@ packages:
   /html-escaper/2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  /http-errors/1.3.1:
-    resolution: {integrity: sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=}
-    engines: {node: '>= 0.6'}
-    dependencies:
-      inherits: 2.0.4
-      statuses: 1.2.1
-    dev: false
-
   /http-errors/1.6.3:
-    resolution: {integrity: sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=}
+    resolution: {integrity: sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==}
     engines: {node: '>= 0.6'}
     dependencies:
       depd: 1.1.2
       inherits: 2.0.3
       setprototypeof: 1.1.0
-      statuses: 1.4.0
+      statuses: 1.5.0
     dev: false
 
   /http-errors/1.7.3:
@@ -6749,11 +6709,6 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
     dev: true
-
-  /iconv-lite/0.4.13:
-    resolution: {integrity: sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=}
-    engines: {node: '>=0.8.0'}
-    dev: false
 
   /iconv-lite/0.4.23:
     resolution: {integrity: sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==}
@@ -6837,7 +6792,7 @@ packages:
     dev: false
 
   /inherits/2.0.3:
-    resolution: {integrity: sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=}
+    resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
     dev: false
 
   /inherits/2.0.4:
@@ -8706,7 +8661,7 @@ packages:
     dev: false
 
   /map-stream/0.0.7:
-    resolution: {integrity: sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=}
+    resolution: {integrity: sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==}
     dev: false
 
   /map-visit/1.0.0:
@@ -8836,11 +8791,6 @@ packages:
     dependencies:
       mime-db: 1.47.0
 
-  /mime/1.3.4:
-    resolution: {integrity: sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=}
-    hasBin: true
-    dev: false
-
   /mime/1.4.1:
     resolution: {integrity: sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==}
     hasBin: true
@@ -8945,12 +8895,8 @@ packages:
       run-queue: 1.0.3
     dev: false
 
-  /ms/0.7.1:
-    resolution: {integrity: sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=}
-    dev: false
-
   /ms/2.0.0:
-    resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=}
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   /ms/2.1.1:
     resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
@@ -9277,7 +9223,7 @@ packages:
       es-abstract: 1.19.1
 
   /on-finished/2.3.0:
-    resolution: {integrity: sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=}
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
     dependencies:
       ee-first: 1.1.1
@@ -9552,12 +9498,6 @@ packages:
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-
-  /pause-stream/0.0.11:
-    resolution: {integrity: sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=}
-    dependencies:
-      through: 2.3.8
-    dev: false
 
   /pbkdf2/3.1.2:
     resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
@@ -9845,16 +9785,6 @@ packages:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
 
-  /qs/5.1.0:
-    resolution: {integrity: sha1-TZMuXH6kEcynajEtOaYGIA/VDNk=}
-    engines: {'0': '>', '1': '=', '2': '0', '3': ., '4': '1', '5': '0', '6': ., '7': '4', '8': '0'}
-    dev: false
-
-  /qs/5.2.0:
-    resolution: {integrity: sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=}
-    engines: {'0': '>', '1': '=', '2': '0', '3': ., '4': '1', '5': '0', '6': ., '7': '4', '8': '0'}
-    dev: false
-
   /qs/6.5.2:
     resolution: {integrity: sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==}
     engines: {node: '>=0.6'}
@@ -9889,23 +9819,17 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /range-parser/1.0.3:
-    resolution: {integrity: sha1-aHKCNTXGkuLCoBA4Jq/YLC4P8XU=}
-    engines: {node: '>= 0.6'}
-    dev: false
-
   /range-parser/1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
     dev: false
 
-  /raw-body/2.1.7:
-    resolution: {integrity: sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=}
-    engines: {node: '>= 0.8'}
+  /raw-body/1.1.7:
+    resolution: {integrity: sha512-WmJJU2e9Y6M5UzTOkHaM7xJGAPQD8PNzx3bAd2+uhZAim6wDk6dAZxPVYLF67XhbR4hmKGh33Lpmh4XWrCH5Mg==}
+    engines: {node: '>= 0.8.0'}
     dependencies:
-      bytes: 2.4.0
-      iconv-lite: 0.4.13
-      unpipe: 1.0.0
+      bytes: 1.0.0
+      string_decoder: 0.10.31
     dev: false
 
   /raw-body/2.3.3:
@@ -10292,6 +10216,10 @@ packages:
   /safe-buffer/5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  /safe-json-parse/1.0.1:
+    resolution: {integrity: sha512-o0JmTu17WGUaUOHa1l0FPGXKBfijbxK6qoHzlkihsDXxzBHvJcA7zgviKR92Xs841rX9pK16unfphLq0/KqX7A==}
+    dev: false
+
   /safe-regex/1.1.0:
     resolution: {integrity: sha1-QKNmnzsHfR6UPURinhV91IAjvy4=}
     dependencies:
@@ -10378,24 +10306,6 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
-  /send/0.13.2:
-    resolution: {integrity: sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=}
-    engines: {node: '>= 0.8.0'}
-    dependencies:
-      debug: 2.2.0
-      depd: 1.1.2
-      destroy: 1.0.4
-      escape-html: 1.0.3
-      etag: 1.7.0
-      fresh: 0.3.0
-      http-errors: 1.3.1
-      mime: 1.3.4
-      ms: 0.7.1
-      on-finished: 2.3.0
-      range-parser: 1.0.3
-      statuses: 1.2.1
-    dev: false
-
   /send/0.16.2:
     resolution: {integrity: sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==}
     engines: {node: '>= 0.8.0'}
@@ -10445,7 +10355,7 @@ packages:
     dev: false
 
   /serve-index/1.9.1:
-    resolution: {integrity: sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=}
+    resolution: {integrity: sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==}
     engines: {node: '>= 0.8.0'}
     dependencies:
       accepts: 1.3.7
@@ -10655,12 +10565,6 @@ packages:
     dependencies:
       extend-shallow: 3.0.2
 
-  /split/1.0.1:
-    resolution: {integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==}
-    dependencies:
-      through: 2.3.8
-    dev: false
-
   /sprintf-js/1.0.3:
     resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
 
@@ -10708,17 +10612,13 @@ packages:
       define-property: 0.2.5
       object-copy: 0.1.0
 
-  /statuses/1.2.1:
-    resolution: {integrity: sha1-3e1FzBglbVHtQK7BQkidXGECbSg=}
-    dev: false
-
   /statuses/1.4.0:
     resolution: {integrity: sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==}
     engines: {node: '>= 0.6'}
     dev: false
 
   /statuses/1.5.0:
-    resolution: {integrity: sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=}
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -10731,13 +10631,6 @@ packages:
     dependencies:
       inherits: 2.0.4
       readable-stream: 2.3.7
-    dev: false
-
-  /stream-combiner/0.2.2:
-    resolution: {integrity: sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=}
-    dependencies:
-      duplexer: 0.1.2
-      through: 2.3.8
     dev: false
 
   /stream-consume/0.1.1:
@@ -10788,6 +10681,10 @@ packages:
       char-regex: 1.0.2
       strip-ansi: 6.0.1
     dev: true
+
+  /string-template/0.2.1:
+    resolution: {integrity: sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==}
+    dev: false
 
   /string-width/1.0.2:
     resolution: {integrity: sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=}
@@ -10851,7 +10748,7 @@ packages:
       define-properties: 1.1.3
 
   /string_decoder/0.10.31:
-    resolution: {integrity: sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=}
+    resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
 
   /string_decoder/1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -11069,10 +10966,6 @@ packages:
     resolution: {integrity: sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==}
     dev: true
 
-  /through/2.3.8:
-    resolution: {integrity: sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=}
-    dev: false
-
   /through2-filter/3.0.0:
     resolution: {integrity: sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==}
     dependencies:
@@ -11086,7 +10979,7 @@ packages:
       xtend: 4.0.2
 
   /time-stamp/1.1.0:
-    resolution: {integrity: sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=}
+    resolution: {integrity: sha512-gLCeArryy2yNTRzTGKbZbloctj64jkZ57hj5zdraXue6aFgd6PmvVtEyiUU+hvU0v7q08oVv8r8ev0tRo6bvgw==}
     engines: {node: '>=0.10.0'}
 
   /timers-browserify/2.0.12:
@@ -11099,15 +10992,15 @@ packages:
   /timsort/0.3.0:
     resolution: {integrity: sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=}
 
-  /tiny-lr/0.2.1:
-    resolution: {integrity: sha1-s/26gC5dVqM8L28QeUsy5Hescp0=}
+  /tiny-lr/1.1.1:
+    resolution: {integrity: sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==}
     dependencies:
-      body-parser: 1.14.2
-      debug: 2.2.0
+      body: 5.1.0
+      debug: 3.1.0
       faye-websocket: 0.10.0
       livereload-js: 2.4.0
-      parseurl: 1.3.3
-      qs: 5.1.0
+      object-assign: 4.1.1
+      qs: 6.5.2
     dev: false
 
   /tmpl/1.0.4:
@@ -12209,7 +12102,7 @@ packages:
     dev: true
 
   /unpipe/1.0.0:
-    resolution: {integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=}
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
     dev: false
 
@@ -12267,7 +12160,7 @@ packages:
     dev: false
 
   /utils-merge/1.0.1:
-    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
     dev: false
 

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "a5c52ab9dc4b9a096367bf93b11b9a04e740239c",
+  "pnpmShrinkwrapHash": "e9d34282627da8ccebd6e60846d23592e0e7f8e7",
   "preferredVersionsHash": "6a96c5550f3ce50aa19e8d1141c6c5d4176953ff"
 }

--- a/core-build/gulp-core-build-serve/package.json
+++ b/core-build/gulp-core-build-serve/package.json
@@ -20,7 +20,7 @@
     "colors": "~1.2.1",
     "express": "~4.16.2",
     "gulp": "~4.0.2",
-    "gulp-connect": "~5.5.0",
+    "gulp-connect": "~5.7.0",
     "gulp-open": "~3.0.1",
     "sudo": "~1.0.3"
   },


### PR DESCRIPTION
`gulp-connect` has a dependency on a package called `qs`, which has a vulnerability. This PR upgrades `gulp-connect` to get an upgraded version of `qs`.