### PR TITLE
Downgrade eslint config to a version that allows for TypeScript 4.5

### DIFF
--- a/build-tests/node-library-build-eslint-test/package.json
+++ b/build-tests/node-library-build-eslint-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-2.4-library-test/package.json
+++ b/build-tests/rush-stack-compiler-2.4-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-2.4": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-2.7-library-test/package.json
+++ b/build-tests/rush-stack-compiler-2.7-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-2.7": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-2.8-library-test/package.json
+++ b/build-tests/rush-stack-compiler-2.8-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-2.8": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-2.9-library-test/package.json
+++ b/build-tests/rush-stack-compiler-2.9-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-2.9": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-3.0-library-test/package.json
+++ b/build-tests/rush-stack-compiler-3.0-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.0": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-3.1-library-test/package.json
+++ b/build-tests/rush-stack-compiler-3.1-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.1": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-3.2-library-test/package.json
+++ b/build-tests/rush-stack-compiler-3.2-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.2": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-3.3-library-test/package.json
+++ b/build-tests/rush-stack-compiler-3.3-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.3": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-3.4-library-test/package.json
+++ b/build-tests/rush-stack-compiler-3.4-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.4": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-3.5-library-test/package.json
+++ b/build-tests/rush-stack-compiler-3.5-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.5": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-3.6-library-test/package.json
+++ b/build-tests/rush-stack-compiler-3.6-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.6": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-3.7-library-test/package.json
+++ b/build-tests/rush-stack-compiler-3.7-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.7": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-3.8-library-test/package.json
+++ b/build-tests/rush-stack-compiler-3.8-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.8": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-3.9-library-test/package.json
+++ b/build-tests/rush-stack-compiler-3.9-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-4.0-library-test/package.json
+++ b/build-tests/rush-stack-compiler-4.0-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-4.0": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-4.1-library-test/package.json
+++ b/build-tests/rush-stack-compiler-4.1-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-4.1": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-4.2-library-test/package.json
+++ b/build-tests/rush-stack-compiler-4.2-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-4.2": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/build-tests/rush-stack-compiler-4.5-library-test/package.json
+++ b/build-tests/rush-stack-compiler-4.5-library-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-4.5": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
     "gulp": "~4.0.2"

--- a/common/changes/@microsoft/gulp-core-build-mocha/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/gulp-core-build-mocha/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-mocha",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-mocha"
+}

--- a/common/changes/@microsoft/gulp-core-build-sass/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/gulp-core-build-sass/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-sass",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-sass"
+}

--- a/common/changes/@microsoft/gulp-core-build-serve/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/gulp-core-build-serve/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-serve",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-serve"
+}

--- a/common/changes/@microsoft/gulp-core-build-typescript/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/gulp-core-build-typescript/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-typescript",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-typescript"
+}

--- a/common/changes/@microsoft/gulp-core-build-webpack/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/gulp-core-build-webpack/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build-webpack",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build-webpack"
+}

--- a/common/changes/@microsoft/gulp-core-build/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/gulp-core-build/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/gulp-core-build",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/gulp-core-build"
+}

--- a/common/changes/@microsoft/node-library-build/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/node-library-build/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/node-library-build",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/node-library-build"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.4/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.4/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.4",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.4"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.7/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.7/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.7",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.7"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.8/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.8/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.8",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.8"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-2.9/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-2.9/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-2.9",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-2.9"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.0/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.0/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.0",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.0"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.1/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.1/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.1",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.1"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.2/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.2/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.2",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.2"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.3/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.3/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.3",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.3"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.4/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.4/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.4",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.4"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.5/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.5/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.5",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.5"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.6/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.6/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.6",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.6"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.7/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.7/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.7",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.7"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.8/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.8/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.8",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.8"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-3.9/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-3.9/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-3.9",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-3.9"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-4.0/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-4.0/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-4.0",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-4.0"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-4.1/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-4.1/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-4.1",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-4.1"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-4.2/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-4.2/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-4.2",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-4.2"
+}

--- a/common/changes/@microsoft/rush-stack-compiler-4.5/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/rush-stack-compiler-4.5/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush-stack-compiler-4.5",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/rush-stack-compiler-4.5"
+}

--- a/common/changes/@microsoft/web-library-build/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
+++ b/common/changes/@microsoft/web-library-build/nick-pape-downgrade-eslint-config_2023-04-13-16-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/web-library-build",
+      "comment": "Downgrade eslint-config to resolve typescript compiler peer dependency issue.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/web-library-build"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.9': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -37,14 +37,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-2.4': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-2.4': link:../../stack/rush-stack-compiler-2.4
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -53,14 +53,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-2.7': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-2.7': link:../../stack/rush-stack-compiler-2.7
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -69,14 +69,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-2.8': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-2.8': link:../../stack/rush-stack-compiler-2.8
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -85,14 +85,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-2.9': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-2.9': link:../../stack/rush-stack-compiler-2.9
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -101,14 +101,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.0': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-3.0': link:../../stack/rush-stack-compiler-3.0
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -117,14 +117,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.1': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-3.1': link:../../stack/rush-stack-compiler-3.1
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -133,14 +133,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.2': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-3.2': link:../../stack/rush-stack-compiler-3.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -149,14 +149,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.3': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-3.3': link:../../stack/rush-stack-compiler-3.3
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -165,14 +165,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.4': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-3.4': link:../../stack/rush-stack-compiler-3.4
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -181,14 +181,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.5': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-3.5': link:../../stack/rush-stack-compiler-3.5
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -197,14 +197,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.6': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-3.6': link:../../stack/rush-stack-compiler-3.6
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -213,14 +213,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.7': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-3.7': link:../../stack/rush-stack-compiler-3.7
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -229,14 +229,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.8': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-3.8': link:../../stack/rush-stack-compiler-3.8
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -245,14 +245,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.9': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -261,14 +261,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-4.0': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-4.0': link:../../stack/rush-stack-compiler-4.0
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -277,14 +277,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-4.1': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-4.1': link:../../stack/rush-stack-compiler-4.1
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -293,14 +293,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-4.2': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-4.2': link:../../stack/rush-stack-compiler-4.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -309,14 +309,14 @@ importers:
     specifiers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-4.5': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/node': 10.17.13
       eslint: ~7.12.1
       gulp: ~4.0.2
     devDependencies:
       '@microsoft/node-library-build': link:../../core-build/node-library-build
       '@microsoft/rush-stack-compiler-4.5': link:../../stack/rush-stack-compiler-4.5
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/node': 10.17.13
       eslint: 7.12.1
       gulp: 4.0.2
@@ -341,7 +341,7 @@ importers:
       '@jest/reporters': ~25.4.0
       '@microsoft/node-library-build': 6.5.21
       '@microsoft/rush-stack-compiler-3.9': 0.4.42
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/node-core-library': ~3.53.0
       '@types/chalk': 0.4.31
       '@types/glob': 7.1.1
@@ -425,7 +425,7 @@ importers:
     devDependencies:
       '@microsoft/node-library-build': 6.5.21
       '@microsoft/rush-stack-compiler-3.9': 0.4.42
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/glob': 7.1.1
       '@types/z-schema': 3.16.31
       eslint: 7.12.1
@@ -435,7 +435,7 @@ importers:
       '@microsoft/gulp-core-build': workspace:*
       '@microsoft/node-library-build': 6.5.21
       '@microsoft/rush-stack-compiler-3.9': 0.4.42
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/glob': 7.1.1
       '@types/gulp': 4.0.6
       '@types/gulp-istanbul': 0.9.30
@@ -458,7 +458,7 @@ importers:
     devDependencies:
       '@microsoft/node-library-build': 6.5.21
       '@microsoft/rush-stack-compiler-3.9': 0.4.42
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/glob': 7.1.1
       '@types/gulp': 4.0.6
       '@types/gulp-istanbul': 0.9.30
@@ -473,7 +473,7 @@ importers:
       '@microsoft/load-themed-styles': ~1.10.172
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.9': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/node-core-library': ~3.53.0
       '@types/autoprefixer': 9.7.2
       '@types/clean-css': 4.2.1
@@ -506,7 +506,7 @@ importers:
     devDependencies:
       '@microsoft/node-library-build': link:../node-library-build
       '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/autoprefixer': 9.7.2
       '@types/clean-css': 4.2.1
       '@types/glob': 7.1.1
@@ -522,7 +522,7 @@ importers:
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@rushstack/debug-certificate-manager': ~1.1.19
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/node-core-library': ~3.53.0
       '@types/express': 4.11.0
       '@types/express-serve-static-core': 4.11.0
@@ -554,7 +554,7 @@ importers:
     devDependencies:
       '@microsoft/node-library-build': link:../node-library-build
       '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/express': 4.11.0
       '@types/express-serve-static-core': 4.11.0
       '@types/gulp': 4.0.6
@@ -571,7 +571,7 @@ importers:
       '@microsoft/gulp-core-build': workspace:*
       '@microsoft/node-library-build': 6.5.21
       '@microsoft/rush-stack-compiler-4.5': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/node-core-library': ~3.53.0
       '@types/glob': 7.1.1
       '@types/node': 10.17.13
@@ -595,7 +595,7 @@ importers:
       '@microsoft/api-extractor': 7.15.2
       '@microsoft/node-library-build': 6.5.21
       '@microsoft/rush-stack-compiler-4.5': link:../../stack/rush-stack-compiler-4.5
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/glob': 7.1.1
       '@types/resolve': 1.17.1
       eslint: 7.12.1
@@ -607,7 +607,7 @@ importers:
       '@microsoft/gulp-core-build': workspace:*
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-3.9': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/gulp': 4.0.6
       '@types/node': 10.17.13
       '@types/orchestrator': 0.0.30
@@ -630,7 +630,7 @@ importers:
     devDependencies:
       '@microsoft/node-library-build': link:../node-library-build
       '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@types/orchestrator': 0.0.30
       '@types/source-map': 0.5.0
       '@types/tapable': 1.0.6
@@ -645,7 +645,7 @@ importers:
       '@microsoft/gulp-core-build-mocha': workspace:*
       '@microsoft/gulp-core-build-typescript': workspace:*
       '@microsoft/rush-stack-compiler-3.9': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/gulp': 4.0.6
       '@types/node': 10.17.13
       eslint: ~7.12.1
@@ -659,7 +659,7 @@ importers:
       gulp: 4.0.2
     devDependencies:
       '@microsoft/rush-stack-compiler-3.9': link:../../stack/rush-stack-compiler-3.9
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       eslint: 7.12.1
 
   ../../core-build/web-library-build:
@@ -671,7 +671,7 @@ importers:
       '@microsoft/gulp-core-build-webpack': workspace:*
       '@microsoft/node-library-build': workspace:*
       '@microsoft/rush-stack-compiler-4.5': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@types/gulp': 4.0.6
       '@types/node': 10.17.13
       eslint: ~7.12.1
@@ -690,7 +690,7 @@ importers:
     devDependencies:
       '@microsoft/node-library-build': link:../node-library-build
       '@microsoft/rush-stack-compiler-4.5': link:../../stack/rush-stack-compiler-4.5
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       eslint: 7.12.1
 
   ../../stack/rush-stack-compiler-2.4:
@@ -698,7 +698,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -710,7 +710,7 @@ importers:
       typescript: ~2.4.2
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -729,7 +729,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -741,7 +741,7 @@ importers:
       typescript: ~2.7.2
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -760,7 +760,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -772,7 +772,7 @@ importers:
       typescript: ~2.8.4
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -791,7 +791,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -803,7 +803,7 @@ importers:
       typescript: ~2.9.2
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -822,7 +822,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -834,7 +834,7 @@ importers:
       typescript: ~3.0.3
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -853,7 +853,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -865,7 +865,7 @@ importers:
       typescript: ~3.1.6
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -884,7 +884,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -896,7 +896,7 @@ importers:
       typescript: ~3.2.4
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -915,7 +915,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -927,7 +927,7 @@ importers:
       typescript: ~3.3.3
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -946,7 +946,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -958,7 +958,7 @@ importers:
       typescript: ~3.4.3
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -977,7 +977,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -989,7 +989,7 @@ importers:
       typescript: ~3.5.3
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -1008,7 +1008,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -1020,7 +1020,7 @@ importers:
       typescript: ~3.6.4
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -1039,7 +1039,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -1051,7 +1051,7 @@ importers:
       typescript: ~3.7.2
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -1070,7 +1070,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -1082,7 +1082,7 @@ importers:
       typescript: ~3.8.3
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -1101,7 +1101,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': 0.4.42
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -1113,7 +1113,7 @@ importers:
       typescript: ~3.9.7
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -1132,7 +1132,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -1142,7 +1142,7 @@ importers:
       typescript: ~4.0.7
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -1159,7 +1159,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -1169,7 +1169,7 @@ importers:
       typescript: ~4.1.5
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -1186,7 +1186,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -1196,7 +1196,7 @@ importers:
       typescript: ~4.2.4
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0_eslint@7.12.1
+      '@rushstack/eslint-config': 2.6.2_eslint@7.12.1
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       eslint: 7.12.1
@@ -1213,7 +1213,7 @@ importers:
       '@microsoft/api-extractor': ~7.15.2
       '@microsoft/rush-stack-compiler-3.9': workspace:*
       '@microsoft/rush-stack-compiler-shared': workspace:*
-      '@rushstack/eslint-config': ~3.1.0
+      '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': 0.48.0
       '@rushstack/heft-node-rig': 1.11.0
       '@rushstack/node-core-library': ~3.53.0
@@ -1222,7 +1222,7 @@ importers:
       typescript: ~4.5.5
     dependencies:
       '@microsoft/api-extractor': 7.15.2
-      '@rushstack/eslint-config': 3.1.0
+      '@rushstack/eslint-config': 2.6.2
       '@rushstack/node-core-library': 3.53.0
       '@types/node': 10.17.13
       import-lazy: 4.0.0
@@ -2249,19 +2249,19 @@ packages:
       - supports-color
     dev: true
 
-  /@rushstack/eslint-config/3.1.0:
-    resolution: {integrity: sha512-1xV215H326tBe6rd7YNiOkJSFRMHngBcn6MADHna5bpKzGfUKjg0tG74Wp6Js8SPMKG+3D7h0J1wN9fyBatphw==}
+  /@rushstack/eslint-config/2.6.2:
+    resolution: {integrity: sha512-EcZENq5HlXe5XN9oFZ90K8y946zBXRgliNhy+378H0oK00v3FYADj8aSisEHS5OWz4HO0hYWe6IU57CNg+syYQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@rushstack/eslint-patch': 1.2.0
-      '@rushstack/eslint-plugin': 0.11.0_typescript@4.8.4
-      '@rushstack/eslint-plugin-packlets': 0.6.0_typescript@4.8.4
-      '@rushstack/eslint-plugin-security': 0.5.0_typescript@4.8.4
-      '@typescript-eslint/eslint-plugin': 5.38.1_b1d54454612116594b587228f17204c2
-      '@typescript-eslint/experimental-utils': 5.38.1_typescript@4.8.4
-      '@typescript-eslint/parser': 5.38.1_typescript@4.8.4
-      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.4
+      '@rushstack/eslint-patch': 1.1.4
+      '@rushstack/eslint-plugin': 0.9.1_typescript@4.8.4
+      '@rushstack/eslint-plugin-packlets': 0.4.1_typescript@4.8.4
+      '@rushstack/eslint-plugin-security': 0.3.1_typescript@4.8.4
+      '@typescript-eslint/eslint-plugin': 5.20.0_cf4a5ae68a4cce47c03d77acc8d21cc8
+      '@typescript-eslint/experimental-utils': 5.20.0_typescript@4.8.4
+      '@typescript-eslint/parser': 5.20.0_typescript@4.8.4
+      '@typescript-eslint/typescript-estree': 5.20.0_typescript@4.8.4
       eslint-plugin-promise: 6.0.1
       eslint-plugin-react: 7.27.1
       eslint-plugin-tsdoc: 0.2.17
@@ -2270,19 +2270,19 @@ packages:
       - supports-color
     dev: false
 
-  /@rushstack/eslint-config/3.1.0_eslint@7.12.1:
-    resolution: {integrity: sha512-1xV215H326tBe6rd7YNiOkJSFRMHngBcn6MADHna5bpKzGfUKjg0tG74Wp6Js8SPMKG+3D7h0J1wN9fyBatphw==}
+  /@rushstack/eslint-config/2.6.2_eslint@7.12.1:
+    resolution: {integrity: sha512-EcZENq5HlXe5XN9oFZ90K8y946zBXRgliNhy+378H0oK00v3FYADj8aSisEHS5OWz4HO0hYWe6IU57CNg+syYQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@rushstack/eslint-patch': 1.2.0
-      '@rushstack/eslint-plugin': 0.11.0_eslint@7.12.1+typescript@4.8.4
-      '@rushstack/eslint-plugin-packlets': 0.6.0_eslint@7.12.1+typescript@4.8.4
-      '@rushstack/eslint-plugin-security': 0.5.0_eslint@7.12.1+typescript@4.8.4
-      '@typescript-eslint/eslint-plugin': 5.38.1_3a04e3c0829ca025f448acbdc4398d6c
-      '@typescript-eslint/experimental-utils': 5.38.1_eslint@7.12.1+typescript@4.8.4
-      '@typescript-eslint/parser': 5.38.1_eslint@7.12.1+typescript@4.8.4
-      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.4
+      '@rushstack/eslint-patch': 1.1.4
+      '@rushstack/eslint-plugin': 0.9.1_eslint@7.12.1+typescript@4.8.4
+      '@rushstack/eslint-plugin-packlets': 0.4.1_eslint@7.12.1+typescript@4.8.4
+      '@rushstack/eslint-plugin-security': 0.3.1_eslint@7.12.1+typescript@4.8.4
+      '@typescript-eslint/eslint-plugin': 5.20.0_81ce1d894be9f511f0c0d6ac029c23a4
+      '@typescript-eslint/experimental-utils': 5.20.0_eslint@7.12.1+typescript@4.8.4
+      '@typescript-eslint/parser': 5.20.0_eslint@7.12.1+typescript@4.8.4
+      '@typescript-eslint/typescript-estree': 5.20.0_typescript@4.8.4
       eslint: 7.12.1
       eslint-plugin-promise: 6.0.1_eslint@7.12.1
       eslint-plugin-react: 7.27.1_eslint@7.12.1
@@ -2295,8 +2295,8 @@ packages:
     resolution: {integrity: sha512-Myxw//kzromB9yWgS8qYGuGVf91oBUUJpNvy5eM50sqvmKLbKjwLxohJnkWGTeeI9v9IBMtPLxz5Gc60FIfvCA==}
     dev: true
 
-  /@rushstack/eslint-patch/1.2.0:
-    resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
+  /@rushstack/eslint-patch/1.1.4:
+    resolution: {integrity: sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==}
 
   /@rushstack/eslint-plugin-packlets/0.2.1_eslint@7.12.1+typescript@4.1.5:
     resolution: {integrity: sha512-TAcoC/v8h+e9lcrE6Am5ZbwDZ18FHEfMIsU75Mj8sVg9JCd1Yf6UtLFZJDyZjOFt0oUY41DXPNHALd0py8F56Q==}
@@ -2311,25 +2311,25 @@ packages:
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-packlets/0.6.0_eslint@7.12.1+typescript@4.8.4:
-    resolution: {integrity: sha512-51J5N8UywQamDtBQq6qCCVhHojb753hr26DRe7erIqW+tTMWPfFrb2X5BQxYiFNmkQ6ii4p5RI/6j136IuALHg==}
+  /@rushstack/eslint-plugin-packlets/0.4.1_eslint@7.12.1+typescript@4.8.4:
+    resolution: {integrity: sha512-A+mb+45fAUV6SRRlRy5EXrZAHNTnvOO3ONxw0hmRDcvyPAJwoX0ClkKQriz56QQE5SL4sPxhYoqbkoKbBmsxcA==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.38.1_eslint@7.12.1+typescript@4.8.4
+      '@typescript-eslint/experimental-utils': 5.20.0_eslint@7.12.1+typescript@4.8.4
       eslint: 7.12.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  /@rushstack/eslint-plugin-packlets/0.6.0_typescript@4.8.4:
-    resolution: {integrity: sha512-51J5N8UywQamDtBQq6qCCVhHojb753hr26DRe7erIqW+tTMWPfFrb2X5BQxYiFNmkQ6ii4p5RI/6j136IuALHg==}
+  /@rushstack/eslint-plugin-packlets/0.4.1_typescript@4.8.4:
+    resolution: {integrity: sha512-A+mb+45fAUV6SRRlRy5EXrZAHNTnvOO3ONxw0hmRDcvyPAJwoX0ClkKQriz56QQE5SL4sPxhYoqbkoKbBmsxcA==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/experimental-utils': 5.20.0_typescript@4.8.4
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -2348,49 +2348,25 @@ packages:
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-security/0.5.0_eslint@7.12.1+typescript@4.8.4:
-    resolution: {integrity: sha512-qDtij3D2DY8VDHKeUdf+M2SpoctrY+eIA+fJFkpuHP7CTJZLBv5186+oCsJ59lZmKoBFREdgpaV3coXamoT8RQ==}
+  /@rushstack/eslint-plugin-security/0.3.1_eslint@7.12.1+typescript@4.8.4:
+    resolution: {integrity: sha512-LOBJj7SLPkeonBq2CD9cKqujwgc84YXJP18UXmGYl8xE3OM+Fwgnav7GzsakyvkeWJwq7EtpZjjSW8DTpwfA4w==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.38.1_eslint@7.12.1+typescript@4.8.4
+      '@typescript-eslint/experimental-utils': 5.20.0_eslint@7.12.1+typescript@4.8.4
       eslint: 7.12.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  /@rushstack/eslint-plugin-security/0.5.0_typescript@4.8.4:
-    resolution: {integrity: sha512-qDtij3D2DY8VDHKeUdf+M2SpoctrY+eIA+fJFkpuHP7CTJZLBv5186+oCsJ59lZmKoBFREdgpaV3coXamoT8RQ==}
+  /@rushstack/eslint-plugin-security/0.3.1_typescript@4.8.4:
+    resolution: {integrity: sha512-LOBJj7SLPkeonBq2CD9cKqujwgc84YXJP18UXmGYl8xE3OM+Fwgnav7GzsakyvkeWJwq7EtpZjjSW8DTpwfA4w==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.38.1_typescript@4.8.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: false
-
-  /@rushstack/eslint-plugin/0.11.0_eslint@7.12.1+typescript@4.8.4:
-    resolution: {integrity: sha512-e8eVBOgb/xkpkgFmPP+oifrqCLh8I5BFI/emB/nf5+WnuS4hsTHkgprCEiJuvkhJRypsWrbchkIda9/1YFadxg==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.38.1_eslint@7.12.1+typescript@4.8.4
-      eslint: 7.12.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  /@rushstack/eslint-plugin/0.11.0_typescript@4.8.4:
-    resolution: {integrity: sha512-e8eVBOgb/xkpkgFmPP+oifrqCLh8I5BFI/emB/nf5+WnuS4hsTHkgprCEiJuvkhJRypsWrbchkIda9/1YFadxg==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/experimental-utils': 5.20.0_typescript@4.8.4
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -2408,6 +2384,30 @@ packages:
       - supports-color
       - typescript
     dev: true
+
+  /@rushstack/eslint-plugin/0.9.1_eslint@7.12.1+typescript@4.8.4:
+    resolution: {integrity: sha512-iMfRyk9FE1xdhuenIYwDEjJ67u7ygeFw/XBGJC2j4GHclznHWRfSGiwTeYZ66H74h7NkVTuTp8RYw/x2iDblOA==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.2.4
+      '@typescript-eslint/experimental-utils': 5.20.0_eslint@7.12.1+typescript@4.8.4
+      eslint: 7.12.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  /@rushstack/eslint-plugin/0.9.1_typescript@4.8.4:
+    resolution: {integrity: sha512-iMfRyk9FE1xdhuenIYwDEjJ67u7ygeFw/XBGJC2j4GHclznHWRfSGiwTeYZ66H74h7NkVTuTp8RYw/x2iDblOA==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.2.4
+      '@typescript-eslint/experimental-utils': 5.20.0_typescript@4.8.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
 
   /@rushstack/heft-config-file/0.11.1:
     resolution: {integrity: sha512-Yh3M4B64SsDlF6A18JJDtoyNRNK2ql1QeQHpGQdt4Btv5Dya/kF0sbRvF3JXcE7pFDY0rJLu67OumGUc8nN9pw==}
@@ -2954,8 +2954,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.38.1_3a04e3c0829ca025f448acbdc4398d6c:
-    resolution: {integrity: sha512-ky7EFzPhqz3XlhS7vPOoMDaQnQMn+9o5ICR9CPr/6bw8HrFkzhMSxuA3gRfiJVvs7geYrSeawGJjZoZQKCOglQ==}
+  /@typescript-eslint/eslint-plugin/5.20.0_81ce1d894be9f511f0c0d6ac029c23a4:
+    resolution: {integrity: sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -2965,12 +2965,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.38.1_eslint@7.12.1+typescript@4.8.4
-      '@typescript-eslint/scope-manager': 5.38.1
-      '@typescript-eslint/type-utils': 5.38.1_eslint@7.12.1+typescript@4.8.4
-      '@typescript-eslint/utils': 5.38.1_eslint@7.12.1+typescript@4.8.4
+      '@typescript-eslint/parser': 5.20.0_eslint@7.12.1+typescript@4.8.4
+      '@typescript-eslint/scope-manager': 5.20.0
+      '@typescript-eslint/type-utils': 5.20.0_eslint@7.12.1+typescript@4.8.4
+      '@typescript-eslint/utils': 5.20.0_eslint@7.12.1+typescript@4.8.4
       debug: 4.3.4
       eslint: 7.12.1
+      functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
@@ -2979,8 +2980,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/eslint-plugin/5.38.1_b1d54454612116594b587228f17204c2:
-    resolution: {integrity: sha512-ky7EFzPhqz3XlhS7vPOoMDaQnQMn+9o5ICR9CPr/6bw8HrFkzhMSxuA3gRfiJVvs7geYrSeawGJjZoZQKCOglQ==}
+  /@typescript-eslint/eslint-plugin/5.20.0_cf4a5ae68a4cce47c03d77acc8d21cc8:
+    resolution: {integrity: sha512-fapGzoxilCn3sBtC6NtXZX6+P/Hef7VDbyfGqTTpzYydwhlkevB+0vE0EnmHPVTVSy68GUncyJ/2PcrFBeCo5Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -2990,11 +2991,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.38.1_typescript@4.8.4
-      '@typescript-eslint/scope-manager': 5.38.1
-      '@typescript-eslint/type-utils': 5.38.1_typescript@4.8.4
-      '@typescript-eslint/utils': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/parser': 5.20.0_typescript@4.8.4
+      '@typescript-eslint/scope-manager': 5.20.0
+      '@typescript-eslint/type-utils': 5.20.0_typescript@4.8.4
+      '@typescript-eslint/utils': 5.20.0_typescript@4.8.4
       debug: 4.3.4
+      functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
@@ -3037,25 +3039,25 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.38.1_eslint@7.12.1+typescript@4.8.4:
-    resolution: {integrity: sha512-Zv0EcU0iu64DiVG3pRZU0QYCgANO//U1fS3oEs3eqHD1eIVVcQsFd/T01ckaNbL2H2aCqRojY2xZuMAPcOArEA==}
+  /@typescript-eslint/experimental-utils/5.20.0_eslint@7.12.1+typescript@4.8.4:
+    resolution: {integrity: sha512-w5qtx2Wr9x13Dp/3ic9iGOGmVXK5gMwyc8rwVgZU46K9WTjPZSyPvdER9Ycy+B5lNHvoz+z2muWhUvlTpQeu+g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.38.1_eslint@7.12.1+typescript@4.8.4
+      '@typescript-eslint/utils': 5.20.0_eslint@7.12.1+typescript@4.8.4
       eslint: 7.12.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  /@typescript-eslint/experimental-utils/5.38.1_typescript@4.8.4:
-    resolution: {integrity: sha512-Zv0EcU0iu64DiVG3pRZU0QYCgANO//U1fS3oEs3eqHD1eIVVcQsFd/T01ckaNbL2H2aCqRojY2xZuMAPcOArEA==}
+  /@typescript-eslint/experimental-utils/5.20.0_typescript@4.8.4:
+    resolution: {integrity: sha512-w5qtx2Wr9x13Dp/3ic9iGOGmVXK5gMwyc8rwVgZU46K9WTjPZSyPvdER9Ycy+B5lNHvoz+z2muWhUvlTpQeu+g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/utils': 5.20.0_typescript@4.8.4
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3081,8 +3083,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.38.1_eslint@7.12.1+typescript@4.8.4:
-    resolution: {integrity: sha512-LDqxZBVFFQnQRz9rUZJhLmox+Ep5kdUmLatLQnCRR6523YV+XhRjfYzStQ4MheFA8kMAfUlclHSbu+RKdRwQKw==}
+  /@typescript-eslint/parser/5.20.0_eslint@7.12.1+typescript@4.8.4:
+    resolution: {integrity: sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -3091,17 +3093,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.38.1
-      '@typescript-eslint/types': 5.38.1
-      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/scope-manager': 5.20.0
+      '@typescript-eslint/types': 5.20.0
+      '@typescript-eslint/typescript-estree': 5.20.0_typescript@4.8.4
       debug: 4.3.4
       eslint: 7.12.1
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser/5.38.1_typescript@4.8.4:
-    resolution: {integrity: sha512-LDqxZBVFFQnQRz9rUZJhLmox+Ep5kdUmLatLQnCRR6523YV+XhRjfYzStQ4MheFA8kMAfUlclHSbu+RKdRwQKw==}
+  /@typescript-eslint/parser/5.20.0_typescript@4.8.4:
+    resolution: {integrity: sha512-UWKibrCZQCYvobmu3/N8TWbEeo/EPQbS41Ux1F9XqPzGuV7pfg6n50ZrFo6hryynD8qOTTfLHtHjjdQtxJ0h/w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -3110,24 +3112,24 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.38.1
-      '@typescript-eslint/types': 5.38.1
-      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/scope-manager': 5.20.0
+      '@typescript-eslint/types': 5.20.0
+      '@typescript-eslint/typescript-estree': 5.20.0_typescript@4.8.4
       debug: 4.3.4
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/scope-manager/5.38.1:
-    resolution: {integrity: sha512-BfRDq5RidVU3RbqApKmS7RFMtkyWMM50qWnDAkKgQiezRtLKsoyRKIvz1Ok5ilRWeD9IuHvaidaLxvGx/2eqTQ==}
+  /@typescript-eslint/scope-manager/5.20.0:
+    resolution: {integrity: sha512-h9KtuPZ4D/JuX7rpp1iKg3zOH0WNEa+ZIXwpW/KWmEFDxlA/HSfCMhiyF1HS/drTICjIbpA6OqkAhrP/zkCStg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.38.1
-      '@typescript-eslint/visitor-keys': 5.38.1
+      '@typescript-eslint/types': 5.20.0
+      '@typescript-eslint/visitor-keys': 5.20.0
 
-  /@typescript-eslint/type-utils/5.38.1_eslint@7.12.1+typescript@4.8.4:
-    resolution: {integrity: sha512-UU3j43TM66gYtzo15ivK2ZFoDFKKP0k03MItzLdq0zV92CeGCXRfXlfQX5ILdd4/DSpHkSjIgLLLh1NtkOJOAw==}
+  /@typescript-eslint/type-utils/5.20.0_eslint@7.12.1+typescript@4.8.4:
+    resolution: {integrity: sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -3136,8 +3138,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.4
-      '@typescript-eslint/utils': 5.38.1_eslint@7.12.1+typescript@4.8.4
+      '@typescript-eslint/utils': 5.20.0_eslint@7.12.1+typescript@4.8.4
       debug: 4.3.4
       eslint: 7.12.1
       tsutils: 3.21.0_typescript@4.8.4
@@ -3145,8 +3146,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/type-utils/5.38.1_typescript@4.8.4:
-    resolution: {integrity: sha512-UU3j43TM66gYtzo15ivK2ZFoDFKKP0k03MItzLdq0zV92CeGCXRfXlfQX5ILdd4/DSpHkSjIgLLLh1NtkOJOAw==}
+  /@typescript-eslint/type-utils/5.20.0_typescript@4.8.4:
+    resolution: {integrity: sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -3155,8 +3156,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.4
-      '@typescript-eslint/utils': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/utils': 5.20.0_typescript@4.8.4
       debug: 4.3.4
       tsutils: 3.21.0_typescript@4.8.4
       typescript: 4.8.4
@@ -3169,8 +3169,8 @@ packages:
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     dev: true
 
-  /@typescript-eslint/types/5.38.1:
-    resolution: {integrity: sha512-QTW1iHq1Tffp9lNfbfPm4WJabbvpyaehQ0SrvVK2yfV79SytD9XDVxqiPvdrv2LK7DGSFo91TB2FgWanbJAZXg==}
+  /@typescript-eslint/types/5.20.0:
+    resolution: {integrity: sha512-+d8wprF9GyvPwtoB4CxBAR/s0rpP25XKgnOvMf/gMXYDvlUC3rPFHupdTQ/ow9vn7UDe5rX02ovGYQbv/IUCbg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   /@typescript-eslint/typescript-estree/3.10.1_typescript@4.1.5:
@@ -3216,8 +3216,8 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.38.1_typescript@4.8.4:
-    resolution: {integrity: sha512-99b5e/Enoe8fKMLdSuwrfH/C0EIbpUWmeEKHmQlGZb8msY33qn1KlkFww0z26o5Omx7EVjzVDCWEfrfCDHfE7g==}
+  /@typescript-eslint/typescript-estree/5.20.0_typescript@4.8.4:
+    resolution: {integrity: sha512-36xLjP/+bXusLMrT9fMMYy1KJAGgHhlER2TqpUVDYUQg4w0q/NW/sg4UGAgVwAqb8V4zYg43KMUpM8vV2lve6w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -3225,8 +3225,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.38.1
-      '@typescript-eslint/visitor-keys': 5.38.1
+      '@typescript-eslint/types': 5.20.0
+      '@typescript-eslint/visitor-keys': 5.20.0
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -3236,16 +3236,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils/5.38.1_eslint@7.12.1+typescript@4.8.4:
-    resolution: {integrity: sha512-oIuUiVxPBsndrN81oP8tXnFa/+EcZ03qLqPDfSZ5xIJVm7A9V0rlkQwwBOAGtrdN70ZKDlKv+l1BeT4eSFxwXA==}
+  /@typescript-eslint/utils/5.20.0_eslint@7.12.1+typescript@4.8.4:
+    resolution: {integrity: sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 5.38.1
-      '@typescript-eslint/types': 5.38.1
-      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/scope-manager': 5.20.0
+      '@typescript-eslint/types': 5.20.0
+      '@typescript-eslint/typescript-estree': 5.20.0_typescript@4.8.4
       eslint: 7.12.1
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.12.1
@@ -3253,16 +3253,16 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/utils/5.38.1_typescript@4.8.4:
-    resolution: {integrity: sha512-oIuUiVxPBsndrN81oP8tXnFa/+EcZ03qLqPDfSZ5xIJVm7A9V0rlkQwwBOAGtrdN70ZKDlKv+l1BeT4eSFxwXA==}
+  /@typescript-eslint/utils/5.20.0_typescript@4.8.4:
+    resolution: {integrity: sha512-lHONGJL1LIO12Ujyx8L8xKbwWSkoUKFSO+0wDAqGXiudWB2EO7WEUT+YZLtVbmOmSllAjLb9tpoIPwpRe5Tn6w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@types/json-schema': 7.0.9
-      '@typescript-eslint/scope-manager': 5.38.1
-      '@typescript-eslint/types': 5.38.1
-      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.8.4
+      '@typescript-eslint/scope-manager': 5.20.0
+      '@typescript-eslint/types': 5.20.0
+      '@typescript-eslint/typescript-estree': 5.20.0_typescript@4.8.4
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0
     transitivePeerDependencies:
@@ -3277,11 +3277,11 @@ packages:
       eslint-visitor-keys: 1.3.0
     dev: true
 
-  /@typescript-eslint/visitor-keys/5.38.1:
-    resolution: {integrity: sha512-bSHr1rRxXt54+j2n4k54p4fj8AHJ49VDWtjpImOpzQj4qjAiOpPni+V1Tyajh19Api1i844F757cur8wH3YvOA==}
+  /@typescript-eslint/visitor-keys/5.20.0:
+    resolution: {integrity: sha512-1flRpNF+0CAQkMNlTJ6L/Z5jiODG/e5+7mk6XwtPOUS3UrTz3UOiAg9jG2VtKsWI6rZQfy4C6a232QNRZTRGlg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.38.1
+      '@typescript-eslint/types': 5.20.0
       eslint-visitor-keys: 3.3.0
 
   /@webassemblyjs/ast/1.9.0:
@@ -3688,6 +3688,7 @@ packages:
       es-abstract: 1.18.2
       get-intrinsic: 1.1.1
       is-string: 1.0.6
+    dev: true
 
   /array-includes/3.1.4:
     resolution: {integrity: sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==}
@@ -5140,6 +5141,7 @@ packages:
       string.prototype.trimend: 1.0.4
       string.prototype.trimstart: 1.0.4
       unbox-primitive: 1.0.1
+    dev: true
 
   /es-abstract/1.19.1:
     resolution: {integrity: sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==}
@@ -6879,6 +6881,7 @@ packages:
   /is-callable/1.2.3:
     resolution: {integrity: sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==}
     engines: {node: '>= 0.4'}
+    dev: true
 
   /is-callable/1.2.4:
     resolution: {integrity: sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==}
@@ -7049,6 +7052,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       has-symbols: 1.0.2
+    dev: true
 
   /is-regex/1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
@@ -7077,6 +7081,7 @@ packages:
   /is-string/1.0.6:
     resolution: {integrity: sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==}
     engines: {node: '>= 0.4'}
+    dev: true
 
   /is-string/1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -8352,7 +8357,7 @@ packages:
     resolution: {integrity: sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==}
     engines: {node: '>=4.0'}
     dependencies:
-      array-includes: 3.1.3
+      array-includes: 3.1.4
       object.assign: 4.1.2
 
   /just-debounce/1.1.0:
@@ -9110,6 +9115,7 @@ packages:
 
   /object-inspect/1.10.3:
     resolution: {integrity: sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==}
+    dev: true
 
   /object-inspect/1.11.1:
     resolution: {integrity: sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "e9d34282627da8ccebd6e60846d23592e0e7f8e7",
+  "pnpmShrinkwrapHash": "0e97bfbc1731cc96e07fd24bf4fc5ffd84afead0",
   "preferredVersionsHash": "6a96c5550f3ce50aa19e8d1141c6c5d4176953ff"
 }

--- a/core-build/gulp-core-build-mocha/package.json
+++ b/core-build/gulp-core-build-mocha/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "6.5.21",
     "@microsoft/rush-stack-compiler-3.9": "0.4.42",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/glob": "7.1.1",
     "@types/gulp": "4.0.6",
     "@types/gulp-istanbul": "0.9.30",

--- a/core-build/gulp-core-build-sass/package.json
+++ b/core-build/gulp-core-build-sass/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/autoprefixer": "9.7.2",
     "@types/clean-css": "4.2.1",
     "@types/glob": "7.1.1",

--- a/core-build/gulp-core-build-serve/package.json
+++ b/core-build/gulp-core-build-serve/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/express": "4.11.0",
     "@types/express-serve-static-core": "4.11.0",
     "@types/gulp": "4.0.6",

--- a/core-build/gulp-core-build-typescript/package.json
+++ b/core-build/gulp-core-build-typescript/package.json
@@ -25,7 +25,7 @@
     "@microsoft/api-extractor": "~7.15.2",
     "@microsoft/node-library-build": "6.5.21",
     "@microsoft/rush-stack-compiler-4.5": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/glob": "7.1.1",
     "@types/resolve": "1.17.1",
     "eslint": "~7.12.1",

--- a/core-build/gulp-core-build-webpack/package.json
+++ b/core-build/gulp-core-build-webpack/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/orchestrator": "0.0.30",
     "@types/source-map": "0.5.0",
     "@types/tapable": "1.0.6",

--- a/core-build/gulp-core-build/package.json
+++ b/core-build/gulp-core-build/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "6.5.21",
     "@microsoft/rush-stack-compiler-3.9": "0.4.42",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@types/glob": "7.1.1",
     "@types/jest": "25.2.1",
     "@types/z-schema": "3.16.31",

--- a/core-build/node-library-build/package.json
+++ b/core-build/node-library-build/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "eslint": "~7.12.1"
   }
 }

--- a/core-build/web-library-build/package.json
+++ b/core-build/web-library-build/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@microsoft/node-library-build": "workspace:*",
     "@microsoft/rush-stack-compiler-4.5": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "eslint": "~7.12.1"
   }
 }

--- a/stack/rush-stack-compiler-2.4/package.json
+++ b/stack/rush-stack-compiler-2.4/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-2.7/package.json
+++ b/stack/rush-stack-compiler-2.7/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-2.8/package.json
+++ b/stack/rush-stack-compiler-2.8/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-2.9/package.json
+++ b/stack/rush-stack-compiler-2.9/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-3.0/package.json
+++ b/stack/rush-stack-compiler-3.0/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-3.1/package.json
+++ b/stack/rush-stack-compiler-3.1/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-3.2/package.json
+++ b/stack/rush-stack-compiler-3.2/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-3.3/package.json
+++ b/stack/rush-stack-compiler-3.3/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-3.4/package.json
+++ b/stack/rush-stack-compiler-3.4/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-3.5/package.json
+++ b/stack/rush-stack-compiler-3.5/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-3.6/package.json
+++ b/stack/rush-stack-compiler-3.6/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-3.7/package.json
+++ b/stack/rush-stack-compiler-3.7/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-3.8/package.json
+++ b/stack/rush-stack-compiler-3.8/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-3.9/package.json
+++ b/stack/rush-stack-compiler-3.9/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "0.4.42",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-4.0/package.json
+++ b/stack/rush-stack-compiler-4.0/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-4.1/package.json
+++ b/stack/rush-stack-compiler-4.1/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-4.2/package.json
+++ b/stack/rush-stack-compiler-4.2/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "eslint": "~7.12.1",
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   }

--- a/stack/rush-stack-compiler-4.5/package.json
+++ b/stack/rush-stack-compiler-4.5/package.json
@@ -20,7 +20,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "@microsoft/api-extractor": "~7.15.2",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/node-core-library": "~3.53.0",
     "@types/node": "10.17.13",
     "import-lazy": "~4.0.0",
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@microsoft/rush-stack-compiler-3.9": "workspace:*",
     "@microsoft/rush-stack-compiler-shared": "workspace:*",
-    "@rushstack/eslint-config": "~3.1.0",
+    "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "0.48.0",
     "@rushstack/heft-node-rig": "1.11.0"
   },


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

See https://github.com/SharePoint/sp-dev-docs/issues/8887 for investigation and details.

Essentially, `eslint-config` was updated to require typescript>4.7. This is causing consumers of all these build rigs to get unmet peer dependency issues. Rolling back to an older version of `eslint-config`, where typescript 4.5 (from the 4.5 build rig) can satisfy this peer dependency.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

Other options could include:
* Creating new build rigs for 4.6, 4.7, etc
* Consumers roll back to prior version of 4.5 build rig.

## How it was tested

* Built the repo, built the sample projects.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->

<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
